### PR TITLE
UTF8 passwords work

### DIFF
--- a/english/js/bip39.js
+++ b/english/js/bip39.js
@@ -106,11 +106,7 @@ function checksumBits(entropyBuffer) {
 }
 
 function salt(password) {
-  return encode_utf8('mnemonic' + (password || ''))
-}
-
-function encode_utf8(s) {
-  return unescape(encodeURIComponent(s))
+  return 'mnemonic' + (password || '')
 }
 
 //=========== helper methods from bitcoinjs-lib ========

--- a/js/bip39.js
+++ b/js/bip39.js
@@ -106,11 +106,7 @@ function checksumBits(entropyBuffer) {
 }
 
 function salt(password) {
-  return encode_utf8('mnemonic' + (password || ''))
-}
-
-function encode_utf8(s) {
-  return unescape(encodeURIComponent(s))
+  return 'mnemonic' + (password || '')
 }
 
 //=========== helper methods from bitcoinjs-lib ========


### PR DESCRIPTION
The encode_utf8 function was altering the salt incorrectly. CryptoJS
handles UTF8 strings properly without having to convert them to the
string equivalent of byte arrays.

Note this isn't noticable with ascii salts, which all the test vectors
are.

This patch should also be made downstream to bip39.js
